### PR TITLE
Create crontask to send reminders about cards changing states. IDC-67 #resolve

### DIFF
--- a/src/main/dml/fenixedu-id-cards.dml
+++ b/src/main/dml/fenixedu-id-cards.dml
@@ -30,6 +30,8 @@ class SantanderEntry {
     String responseLine;    
     String errorDescription;
     String requestReason;
+    Boolean wasExpiringNotified;
+    Boolean wasPickupNotified;
 }
 
 class SantanderCardInfo {	

--- a/src/main/java/org/fenixedu/idcards/domain/SantanderEntry.java
+++ b/src/main/java/org/fenixedu/idcards/domain/SantanderEntry.java
@@ -55,6 +55,7 @@ public class SantanderEntry extends SantanderEntry_Base {
         setRequestLine(requestedCardBean.getRequestLine());
         setResponseLine("");
         setErrorDescription("");
+        setWasPickupNotified(true);
         SantanderCardInfo cardInfo = new SantanderCardInfo();
         cardInfo.setIdentificationNumber(requestedCardBean.getIdentificationNumber());
         cardInfo.setCardName(requestedCardBean.getCardName());
@@ -78,8 +79,13 @@ public class SantanderEntry extends SantanderEntry_Base {
         updateState(SantanderCardState.NEW, requestDate);
         updateState(SantanderCardState.ISSUED, requestedCardBean.getProductionDate());
 
-        if (DateTime.now().isAfter(cardExpiryTime))
+        if (DateTime.now().isAfter(cardExpiryTime)) {
             updateState(SantanderCardState.EXPIRED, cardExpiryTime);
+            setWasExpiringNotified(true);
+        } else {
+            setWasExpiringNotified(false);
+        }
+
     }
 
     public SantanderEntry(User user, CardPreviewBean cardPreviewBean, PickupLocation pickupLocation, String requestReason) {
@@ -120,6 +126,8 @@ public class SantanderEntry extends SantanderEntry_Base {
         setErrorDescription("");
         setSantanderCardInfo(new SantanderCardInfo(cardPreviewBean, pickupLocation));
         updateState(SantanderCardState.PENDING);
+        setWasExpiringNotified(false);
+        setWasPickupNotified(false);
     }
     
     @Atomic(mode = TxMode.WRITE)

--- a/src/main/java/org/fenixedu/idcards/tasks/SantanderCardsRemindersTask.java
+++ b/src/main/java/org/fenixedu/idcards/tasks/SantanderCardsRemindersTask.java
@@ -1,0 +1,58 @@
+package org.fenixedu.idcards.tasks;
+
+import org.fenixedu.bennu.core.domain.Bennu;
+import org.fenixedu.bennu.core.domain.User;
+import org.fenixedu.bennu.scheduler.CronTask;
+import org.fenixedu.bennu.scheduler.annotation.Task;
+import org.fenixedu.idcards.domain.SantanderCardState;
+import org.fenixedu.idcards.domain.SantanderEntry;
+import org.fenixedu.idcards.notifications.CardNotifications;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import pt.ist.fenixframework.Atomic;
+import pt.ist.fenixframework.FenixFramework;
+
+@Task(englishTitle = "Remind users with expiring cards and cards to pickup", readOnly = true)
+public class SantanderCardsRemindersTask extends CronTask {
+
+    private static final Logger logger = LoggerFactory.getLogger(SantanderCardsRemindersTask.class);
+    private final int DAYS_TO_EXPIRE = 90;
+
+    @Override
+    public Atomic.TxMode getTxMode() {
+        return Atomic.TxMode.READ;
+    }
+
+    @Override
+    public void runTask() {
+        Bennu.getInstance().getUserSet().stream()
+                .filter(u -> u.getCurrentSantanderEntry() != null
+                        && (SantanderCardState.ISSUED.equals(u.getCurrentSantanderEntry().getState())
+                                || SantanderCardState.DELIVERED.equals(u.getCurrentSantanderEntry().getState())))
+                .forEach(this::remindUser);
+    }
+
+    private void remindUser(User user) {
+        SantanderEntry entry = user.getCurrentSantanderEntry();
+        SantanderCardState state = entry.getState();
+
+        if (SantanderCardState.DELIVERED.equals(state) && !entry.getWasExpiringNotified()
+                && DateTime.now().isAfter(entry.getSantanderCardInfo().getExpiryDate().minusDays(DAYS_TO_EXPIRE))) {
+            FenixFramework.atomic(() -> {
+                entry.setWasExpiringNotified(true);
+                CardNotifications.notifyCardExpiring(user);
+                logger.debug("Notifying user for expiring card: {}", user.getUsername());
+            });
+        } else if (SantanderCardState.ISSUED.equals(entry.getState()) && !entry.getWasPickupNotified()
+                && DateTime.now().isAfter(entry.getLastUpdate().plusDays(15))
+                && DateTime.now().isBefore(entry.getSantanderCardInfo().getExpiryDate())) {
+            FenixFramework.atomic(() -> {
+                entry.setWasPickupNotified(true);
+                CardNotifications.notifyCardPickup(user);
+                logger.debug("Notifying user to pickup card: {}", user.getUsername());
+            });
+        }
+    }
+}


### PR DESCRIPTION
- Requires https://github.com/ist-dsi/fenixedu-id-cards/pull/67 (IDC-69) to compile.
- Adds 2 attributes to SantanderEntry that require initialization (run task posted on jira - https://jira.fenixedu.org/browse/IDC-67?focusedCommentId=15755&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-15755).

